### PR TITLE
Prevent blocking the event loop thread in the async example

### DIFF
--- a/src/main/scala/org/acme/GreetingResource.scala
+++ b/src/main/scala/org/acme/GreetingResource.scala
@@ -1,5 +1,13 @@
 package org.acme
 
+import java.util.concurrent.CompletionStage
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.DurationInt
+import scala.jdk.FutureConverters.*
+import scala.util.Random
+
 import io.quarkus.logging.Log
 import jakarta.ws.rs.*
 import jakarta.ws.rs.core.MediaType.*
@@ -8,13 +16,6 @@ import org.eclipse.microprofile.config.inject.ConfigProperty
 import org.eclipse.microprofile.metrics.annotation.Counted
 import org.jboss.resteasy.reactive.RestQuery
 import sttp.client3.*
-
-import java.util.concurrent.CompletionStage
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import scala.concurrent.duration.DurationInt
-import scala.jdk.FutureConverters.*
-import scala.util.Random
 
 @Path("/")
 class GreetingResource(

--- a/src/main/scala/org/acme/GreetingResource.scala
+++ b/src/main/scala/org/acme/GreetingResource.scala
@@ -9,6 +9,7 @@ import scala.jdk.FutureConverters.*
 import scala.util.Random
 
 import io.quarkus.logging.Log
+import io.smallrye.common.annotation.Blocking
 import jakarta.ws.rs.*
 import jakarta.ws.rs.core.MediaType.*
 import org.eclipse.microprofile.config.ConfigProvider
@@ -47,7 +48,14 @@ class GreetingResource(
         val names = name.mkString(" and ")
         s"""{"message": "Hello ${names} from RESTEasy Reactive in Scala 3"}"""
 
-    // This is an endpoint which demonstrates how to perform asynchronous operations
+    /**
+     * This is an endpoint which demonstrates how to perform asynchronous
+     * operations. If you call `Await.result` inside this method, annotate it
+     * with @Blocking to make Quarkus move the method to a separate thread pool
+     * meant for blocking operations. Otherwise (as is demonstrated here) return
+     * a `CompletionStage` which can be obtained from Scala Future by using
+     * `scala.jdk.FutureConverters`
+     */
     @GET
     @Path("/greet/async")
     @Produces(Array(TEXT_PLAIN))
@@ -65,7 +73,7 @@ class GreetingResource(
 
         // When both futures are complete, results will be processed in the yield
         // part of the for comprehension.
-        val futures =
+        val futures: Future[String] =
             for
                 sum <- futureSum
                 ip  <- IPFuture.map(_.merge)

--- a/src/test/scala/org/acme/GreetingResourceTest.scala
+++ b/src/test/scala/org/acme/GreetingResourceTest.scala
@@ -2,7 +2,7 @@ package org.acme
 
 import helper.*
 import io.quarkus.test.junit.QuarkusTest
-import org.hamcrest.CoreMatchers.is
+import org.hamcrest.CoreMatchers.{is, containsString}
 import org.junit.jupiter.api.Test
 
 @QuarkusTest
@@ -51,5 +51,17 @@ class GreetingResourceTest:
             "/greet?name=quarkus&name=scala3",
             "Hello quarkus and scala3 from RESTEasy Reactive in Scala 3",
         )
+
+    @Test
+    def testAsyncEndpoint: Unit =
+        Given()
+            .When(req =>
+                req.get("/greet/async")
+            ).ThenAssert(res =>
+                res.statusCode(200)
+                res.body(containsString(
+                    "The sum of the 10 generated numbers is"
+                ))
+            )
 
 end GreetingResourceTest


### PR DESCRIPTION
The async example is using the `Await.result` call which will block the thread it is called from. Quarkus is using the Vert.x event loop for request processing and that event loop should never be blocked (if possible).
That's why Quarkus supports the `@Blocking` annotation (`io.smallrye.common.annotation.Blocking`) to mark the method as blocking. Quarkus will then execute that method on a different thread pool which leaves the event loop available to process other requests. 
Another option (which I used in this PR) is to make the controller method return a CompletionStage[R], which allows Quarkus to access the result of our method in a non-blocking manner.
